### PR TITLE
Hotfix: Fix broken master

### DIFF
--- a/Monster/src/main/java/dk/sdu/mmmi/modulemon/Monster/BattleMonsterProcessor.java
+++ b/Monster/src/main/java/dk/sdu/mmmi/modulemon/Monster/BattleMonsterProcessor.java
@@ -21,9 +21,10 @@ public class BattleMonsterProcessor implements IBattleMonsterProcessor {
 
     @Override
     public IMonster whichMonsterStarts(IMonster iMonster1, IMonster iMonster2) {
-        Monster monster1 = (Monster) iMonster1;
-        Monster monster2 = (Monster) iMonster2;
-        return monster1.getSpeed() >= monster2.getSpeed() ? monster1 : monster2;
+//        Monster monster1 = (Monster) iMonster1;
+//        Monster monster2 = (Monster) iMonster2;
+//        return monster1.getSpeed() >= monster2.getSpeed() ? monster1 : monster2;
+        return iMonster1; //Temp while we figure things out.
     }
 
     @Override

--- a/Monster/src/test/java/dk/sdu/mmmi/modulemon/Monster/MonsterProcessorTest.java
+++ b/Monster/src/test/java/dk/sdu/mmmi/modulemon/Monster/MonsterProcessorTest.java
@@ -4,6 +4,7 @@ import dk.sdu.mmmi.modulemon.CommonMonster.IMonster;
 import dk.sdu.mmmi.modulemon.CommonMonster.MonsterType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
@@ -16,7 +17,7 @@ public class MonsterProcessorTest {
 
     }
 
-
+    @Disabled("This test needs to be updated for the new stats-system as the Speed stat no longer exists.")
     @Test
     void fasterMonsterShouldStart() {
         BattleMonsterProcessor processor = new BattleMonsterProcessor();


### PR DESCRIPTION
When the change where the monster stats were removed, some monster-processing code failed as it still tried to read those values.

Should be properly fixed by @SebMon . This is just so we can actually run the code. 