### PR TITLE
Removed reference from Map to Player and NPC

### DIFF
--- a/Common/src/main/java/dk/sdu/mmmi/modulemon/common/data/Entity.java
+++ b/Common/src/main/java/dk/sdu/mmmi/modulemon/common/data/Entity.java
@@ -8,66 +8,37 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class Entity implements Serializable {
+public abstract class Entity implements Serializable {
     private final UUID ID = UUID.randomUUID();
-
-    private float redValue = 1;
-    private float greenValue = 1;
-    private float blueValue = 1;
-    private float alphaValue = 1;
-
+    private EntityType type;
     private float posX;
     private float posY;
-
     private Texture spriteTexture = null;
-
-    private float[] shapeX = new float[4];
-    private float[] shapeY = new float[4];
-    private float radius;
     private Map<Class, EntityPart> parts;
-    
-    public Entity() {
-        parts = new ConcurrentHashMap<Class, EntityPart>();
+
+    public Entity(EntityType type) {
+        this.type = type;
+        parts = new ConcurrentHashMap<>();
     }
-    
+
+    public Entity(){
+        this(EntityType.GENERIC);
+    }
+
     public void add(EntityPart part) {
         parts.put(part.getClass(), part);
     }
-    
+
     public void remove(Class partClass) {
         parts.remove(partClass);
     }
-    
+
     public <E extends EntityPart> E getPart(Class partClass) {
         return (E) parts.get(partClass);
-    }
-    
-    public void setRadius(float r){
-        this.radius = r;
-    }
-    
-    public float getRadius(){
-        return radius;
     }
 
     public String getID() {
         return ID.toString();
-    }
-
-    public float[] getShapeX() {
-        return shapeX;
-    }
-
-    public void setShapeX(float[] shapeX) {
-        this.shapeX = shapeX;
-    }
-
-    public float[] getShapeY() {
-        return shapeY;
-    }
-
-    public void setShapeY(float[] shapeY) {
-        this.shapeY = shapeY;
     }
 
     public float getPosX() {
@@ -94,35 +65,7 @@ public class Entity implements Serializable {
         this.spriteTexture = spriteTexture;
     }
 
-    public float getRedValue() {
-        return redValue;
-    }
-
-    public float getGreenValue() {
-        return greenValue;
-    }
-
-    public float getBlueValue() {
-        return blueValue;
-    }
-
-    public float getAlphaValue() {
-        return alphaValue;
-    }
-
-    public void setRedValue(float redValue) {
-        this.redValue = redValue;
-    }
-
-    public void setGreenValue(float greenValue) {
-        this.greenValue = greenValue;
-    }
-
-    public void setBlueValue(float blueValue) {
-        this.blueValue = blueValue;
-    }
-
-    public void setAlphaValue(float alphaValue) {
-        this.alphaValue = alphaValue;
+    public EntityType getType() {
+        return type;
     }
 }

--- a/Common/src/main/java/dk/sdu/mmmi/modulemon/common/data/EntityType.java
+++ b/Common/src/main/java/dk/sdu/mmmi/modulemon/common/data/EntityType.java
@@ -1,0 +1,6 @@
+package dk.sdu.mmmi.modulemon.common.data;
+
+public enum EntityType {
+    GENERIC, // For all entities that does not fit into other types
+    PLAYER, // Used for controllable entities. The camera will follow this entity
+}

--- a/Map/pom.xml
+++ b/Map/pom.xml
@@ -29,16 +29,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>Player</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>NPC</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
             <version>4.3.0</version>

--- a/Map/src/main/java/dk/sdu/mmmi/modulemon/Map/MapView.java
+++ b/Map/src/main/java/dk/sdu/mmmi/modulemon/Map/MapView.java
@@ -6,9 +6,9 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.maps.MapProperties;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.renderers.BatchTiledMapRenderer;
@@ -19,19 +19,14 @@ import dk.sdu.mmmi.modulemon.CommonBattleClient.IBattleCallback;
 import dk.sdu.mmmi.modulemon.CommonBattleClient.IBattleResult;
 import dk.sdu.mmmi.modulemon.CommonBattleClient.IBattleView;
 import dk.sdu.mmmi.modulemon.CommonMap.IMapView;
-import dk.sdu.mmmi.modulemon.CommonMonster.IMonster;
-import dk.sdu.mmmi.modulemon.CommonMonster.IMonsterMove;
-import dk.sdu.mmmi.modulemon.CommonMonster.MonsterType;
-import dk.sdu.mmmi.modulemon.Player.PlayerPlugin;
-import dk.sdu.mmmi.modulemon.common.data.*;
 import dk.sdu.mmmi.modulemon.common.OSGiFileHandle;
+import dk.sdu.mmmi.modulemon.common.data.*;
 import dk.sdu.mmmi.modulemon.common.drawing.Rectangle;
 import dk.sdu.mmmi.modulemon.common.drawing.TextUtils;
 import dk.sdu.mmmi.modulemon.common.services.IEntityProcessingService;
 import dk.sdu.mmmi.modulemon.common.services.IGamePluginService;
 import dk.sdu.mmmi.modulemon.common.services.IGameViewService;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
@@ -138,12 +133,11 @@ public class MapView implements IGameViewService, IMapView {
                 spriteBatch.draw(sprite, entity.getPosX(), entity.getPosY());
                 spriteBatch.end();
 
-                if (entity.getClass() == dk.sdu.mmmi.modulemon.Player.Player.class) {
+                if (entity.getType().equals(EntityType.PLAYER)) {
                     playerPosX = entity.getPosX();
                     playerPosY = entity.getPosY();
                     if(playerPosY > mapBottom && playerPosY < mapTop){
                         cam.position.set(cam.position.x, playerPosY, 0);
-
                         cam.update();
                     }
                     if (playerPosX > mapLeft && playerPosX < mapRight) {
@@ -243,7 +237,7 @@ public class MapView implements IGameViewService, IMapView {
                 if (pauseActions[selectedOptionIndex].equals("Team")) {
 
                     for (Entity entity : world.getEntities()) {
-                        if (entity.getClass() == dk.sdu.mmmi.modulemon.Player.Player.class) {
+                        if (entity.getType().equals(EntityType.PLAYER)) {
                             MonsterTeamPart mtp = entity.getPart(MonsterTeamPart.class);
                             mtp.printMonsterTeamNames();
                         }
@@ -267,9 +261,10 @@ public class MapView implements IGameViewService, IMapView {
         }
         if(gameData.getKeys().isPressed(GameKeys.E)){
             for(Entity entity: world.getEntities()){
-                if(entity.getClass() == dk.sdu.mmmi.modulemon.Player.Player.class){
+                if(entity.getType().equals(EntityType.PLAYER)){
                     playerMonsters = entity.getPart(MonsterTeamPart.class);
                     System.out.println("Added playermonsters");
+                    break;
                 }
             }
             startEncounter(playerMonsters, playerMonsters);

--- a/Player/src/main/java/dk/sdu/mmmi/modulemon/Player/Player.java
+++ b/Player/src/main/java/dk/sdu/mmmi/modulemon/Player/Player.java
@@ -1,7 +1,10 @@
 package dk.sdu.mmmi.modulemon.Player;
 
 import dk.sdu.mmmi.modulemon.common.data.Entity;
+import dk.sdu.mmmi.modulemon.common.data.EntityType;
 
 public class Player extends Entity {
-
+    public Player(){
+        super(EntityType.PLAYER);
+    }
 }


### PR DESCRIPTION
Closes #145 

There were references from Map directly to Player and NPC. I removed those. 

Now in order to get the player out from all entities without knowing the class, I added a type to entity. 