### PR TITLE
Fixed split packages, and fixed warnings about exporting

### DIFF
--- a/poms/compiled/pom.xml
+++ b/poms/compiled/pom.xml
@@ -48,8 +48,8 @@
             <!--
              | assume public classes are in the top package, and private classes are under ".internal"
             -->
-            <Export-Package>!${bundle.namespace}.internal.*,${bundle.namespace}.*;version="${project.version}"</Export-Package>
-            <Private-Package>${bundle.namespace}.internal.*</Private-Package>
+            <Export-Package>${bundle.namespace}.*</Export-Package>
+            <Private-Package />
             <!--
              | each module can override these defaults in their osgi.bnd file
             -->


### PR DESCRIPTION
We got a ton of warnings like this:
```
[WARNING] Bundle modulemon.build:Battle:bundle:1.0-SNAPSHOT : Split package, multiple jars provide the same package:dk/sdu/mmmi/modulemon/CommonBattleSimulation
Use Import/Export Package directive -split-package:=(merge-first|merge-last|error|first) to get rid of this warning
Package found in   [Jar:CommonBattleSimulation, Jar:Monster]
Class path         [Jar:., Jar:org.osgi.core, Jar:LibGDX, Jar:gdx, Jar:gdx-platform, Jar:gdx-backend-lwjgl, Jar:lwjgl, Jar:lwjgl-platform, Jar:lwjgl-platform, Jar:lwjgl-platform, Jar:jinput, Jar:jutils, Jar:jinput-platform, Jar:jinput-platform, Jar:jinput-platform, Jar:lwjgl_util, Jar:jlayer, Jar:jorbis, Jar:gdx-box2d, Jar:gdx-freetype, Jar:gdx-platform, Jar:gdx-box2d-platform, Jar:gdx-freetype-platform, Jar:gdx-jnigen, Jar:javaparser, Jar:com.diffplug.osgi.extension.sun.misc, Jar:com.diffplug.osgi.extension.sun.reflect, Jar:Common, Jar:CommonMap, Jar:CommonBattle, Jar:CommonBattleSimulation, Jar:CommonBattleClient, Jar:CommonMonster, Jar:Monster, Jar:json]
```

This is because we had a wrong-configuration of exporting packages. This PR fixes that.

We still get some of those, but that is because `Battle` currently depends on `Monster`. Battle should obviously not do that, but it is necessary for now for testing. However this should also be removed at some point, which will fix the last issue.