### PR TITLE
Added an option to disable disposing when changing gamestates

### DIFF
--- a/Common/src/main/java/dk/sdu/mmmi/modulemon/common/data/IGameStateManager.java
+++ b/Common/src/main/java/dk/sdu/mmmi/modulemon/common/data/IGameStateManager.java
@@ -4,5 +4,6 @@ import dk.sdu.mmmi.modulemon.common.services.IGameViewService;
 
 public interface IGameStateManager {
     void setDefaultState();
+    void setState(IGameViewService state, boolean disposeCurrent);
     void setState(IGameViewService state);
 }

--- a/Core/src/main/java/dk/sdu/mmmi/modulemon/managers/GameStateManager.java
+++ b/Core/src/main/java/dk/sdu/mmmi/modulemon/managers/GameStateManager.java
@@ -13,13 +13,17 @@ public class GameStateManager implements IGameStateManager {
 		setDefaultState();
 	}
 	
-	public void setState(IGameViewService state) {
-		if(currentGameState != null) currentGameState.dispose();
+	public void setState(IGameViewService state, boolean disposeCurrent) {
+		if(currentGameState != null && disposeCurrent) currentGameState.dispose();
 		System.out.println(String.format("Changed state to: %s", state.getClass().getName()));
 		currentGameState = state;
 		currentGameState.init(this);
 	}
-	
+
+	public void setState(IGameViewService state){
+		setState(state, true);
+	}
+
 	public void update(GameData gameData) {
 		currentGameState.update(gameData, this);
 		currentGameState.handleInput(gameData, this);

--- a/Map/src/main/java/dk/sdu/mmmi/modulemon/Map/MapView.java
+++ b/Map/src/main/java/dk/sdu/mmmi/modulemon/Map/MapView.java
@@ -527,7 +527,7 @@ public class MapView implements IGameViewService, IMapView {
         IBattleParticipant playerParticipant = playerMonsters.toBattleParticipant(true);
         IBattleParticipant enemyParticipant = enemyMonsters.toBattleParticipant(false);
 
-        gameStateManager.setState((IGameViewService) battleView);
+        gameStateManager.setState((IGameViewService) battleView, false); // Do not dispose the map
         battleView.startBattle(playerParticipant, enemyParticipant, new IBattleCallback() {
             @Override
             public void onBattleEnd(IBattleResult result) {


### PR DESCRIPTION
It breaks the map, when changing from Battle back to Map, because the camera is disposed. 