### PR TITLE
Updated player etc. to use positionpart instead of entity position

### DIFF
--- a/CommonMap/src/main/java/dk/sdu/mmmi/modulemon/CommonMap/Data/Entity.java
+++ b/CommonMap/src/main/java/dk/sdu/mmmi/modulemon/CommonMap/Data/Entity.java
@@ -1,11 +1,9 @@
 package dk.sdu.mmmi.modulemon.CommonMap.Data;
 
-import com.badlogic.gdx.graphics.Texture;
 import dk.sdu.mmmi.modulemon.CommonMap.Data.EntityParts.EntityPart;
 
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -13,9 +11,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public abstract class Entity implements Serializable {
     private final UUID ID = UUID.randomUUID();
     private EntityType type;
-    private float posX;
-    private float posY;
-    private Texture spriteTexture = null;
     private Map<Class, EntityPart> parts;
 
     public Entity(EntityType type) {
@@ -45,30 +40,6 @@ public abstract class Entity implements Serializable {
 
     public String getID() {
         return ID.toString();
-    }
-
-    public float getPosX() {
-        return posX;
-    }
-
-    public void setPosX(float posX) {
-        this.posX = posX;
-    }
-
-    public float getPosY() {
-        return posY;
-    }
-
-    public void setPosY(float posY) {
-        this.posY = posY;
-    }
-
-    public Texture getSpriteTexture() {
-        return spriteTexture;
-    }
-
-    public void setSpriteTexture(Texture spriteTexture) {
-        this.spriteTexture = spriteTexture;
     }
 
     public EntityType getType() {

--- a/CommonMap/src/main/java/dk/sdu/mmmi/modulemon/CommonMap/Data/EntityParts/SpritePart.java
+++ b/CommonMap/src/main/java/dk/sdu/mmmi/modulemon/CommonMap/Data/EntityParts/SpritePart.java
@@ -12,6 +12,8 @@ public class SpritePart implements EntityPart {
     private Texture leftSprite;
     private Texture rightSprite;
 
+    private Texture currentSprite;
+
     public SpritePart(Texture upSprite, Texture downSprite, Texture leftSprite, Texture rightSprite) {
         this.upSprite = upSprite;
         this.downSprite = downSprite;
@@ -50,6 +52,14 @@ public class SpritePart implements EntityPart {
 
     public void setRightSprite(Texture rightSprite) {
         this.rightSprite = rightSprite;
+    }
+
+    public Texture getCurrentSprite() {
+        return currentSprite;
+    }
+
+    public void setCurrentSprite(Texture currentSprite) {
+        this.currentSprite = currentSprite;
     }
 
     @Override

--- a/Map/src/main/java/dk/sdu/mmmi/modulemon/Map/MapView.java
+++ b/Map/src/main/java/dk/sdu/mmmi/modulemon/Map/MapView.java
@@ -12,6 +12,8 @@ import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.renderers.BatchTiledMapRenderer;
 import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
 import dk.sdu.mmmi.modulemon.CommonMap.Data.Entity;
+import dk.sdu.mmmi.modulemon.CommonMap.Data.EntityParts.PositionPart;
+import dk.sdu.mmmi.modulemon.CommonMap.Data.EntityParts.SpritePart;
 import dk.sdu.mmmi.modulemon.CommonMap.Data.EntityType;
 import dk.sdu.mmmi.modulemon.CommonMap.Data.EntityParts.MonsterTeamPart;
 import dk.sdu.mmmi.modulemon.CommonBattleClient.IBattleCallback;
@@ -159,17 +161,19 @@ public class MapView implements IGameViewService, IMapView {
         tiledMapRenderer.setView(cam);
         tiledMapRenderer.render();
         for (Entity entity : world.getEntities()) {
-            if (entity.getSpriteTexture() != null) {
-                Texture sprite = entity.getSpriteTexture();
+            SpritePart spritePart = entity.getPart(SpritePart.class);
+            if (spritePart.getCurrentSprite() != null) {
+                Texture sprite = spritePart.getCurrentSprite();
 
                 spriteBatch.setProjectionMatrix(cam.combined);
                 spriteBatch.begin();
-                spriteBatch.draw(sprite, entity.getPosX(), entity.getPosY());
+                PositionPart positionPart = entity.getPart(PositionPart.class);
+                spriteBatch.draw(sprite, positionPart.getX(), positionPart.getY());
                 spriteBatch.end();
 
                 if (entity.getType().equals(EntityType.PLAYER)) {
-                    playerPosX = entity.getPosX();
-                    playerPosY = entity.getPosY();
+                    playerPosX = positionPart.getX();
+                    playerPosY = positionPart.getY();
 
                     /*
                     The value of the leftmost position of the camera and the rightmost position of the camera

--- a/NPC/src/main/java/dk/sdu/mmmi/modulemon/NPC/NPCControlSystem.java
+++ b/NPC/src/main/java/dk/sdu/mmmi/modulemon/NPC/NPCControlSystem.java
@@ -82,11 +82,11 @@ public class NPCControlSystem implements IEntityProcessingService{
                 break;
             default: System.out.println(("The NPC sprite could not be loaded: Current did not match any direction"));
         }
-        
 
-        entity.setSpriteTexture(result);
-        entity.setPosX(x);
-        entity.setPosY(y);
+        spritePart.setCurrentSprite(result);
+        //entity.setSpriteTexture(result);
+        positionPart.setX(x);
+        positionPart.setY(y);
     }
     
 }

--- a/Player/src/main/java/dk/sdu/mmmi/modulemon/Player/PlayerControlSystem.java
+++ b/Player/src/main/java/dk/sdu/mmmi/modulemon/Player/PlayerControlSystem.java
@@ -77,9 +77,10 @@ public class PlayerControlSystem implements IEntityProcessingService {
             default: System.out.println(("Did not match any direction"));
         }
 
-        entity.setSpriteTexture(result);
-        entity.setPosX(x);
-        entity.setPosY(y);
+        spritePart.setCurrentSprite(result);
+        //entity.setSpriteTexture(result);
+        positionPart.setX(x);
+        positionPart.setY(y);
     }
 
 


### PR DESCRIPTION
All entities now use PositionPart and SpritePart instead of the values stored in entity.