### PR TITLE
Changed deals damage to base damage

### DIFF
--- a/Monster/src/main/java/dk/sdu/mmmi/modulemon/Monster/MonsterMove.java
+++ b/Monster/src/main/java/dk/sdu/mmmi/modulemon/Monster/MonsterMove.java
@@ -45,7 +45,7 @@ public class MonsterMove implements IMonsterMove {
 
     @Override
     public String getBattleDescription() {
-        return "Move: [" + this.getType() + "] " + this.getName() + ". Deals damage: " + this.getDamage();
+        return "Move: [" + this.getType() + "] " + this.getName() + ". Base damage: " + this.getDamage();
     }
 
     @Override


### PR DESCRIPTION
Just breaking my own rule quickly. I wanted to change "Deals damage" to "Base damage" on the battle screen. 
It feels wrong when it says "Deals damage: 10" and then it actually only deals 6 damage because of the victims high defence stat.